### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,5 +6,5 @@ metadata:
     github.com/project-slug: lokanandaprabhu/ai-release-notes
 spec:
   type: other
+  owner: lokanandaprabhu
   lifecycle: unknown
-  owner: user:development/guest


### PR DESCRIPTION
This PR adds a default catalog-info.yaml for Backstage.